### PR TITLE
Reset `before` value to None in _query_txids between addresses for sol

### DIFF
--- a/src/report_sol.py
+++ b/src/report_sol.py
@@ -164,12 +164,12 @@ def _query_txids(addresses, progress):
     max_queries = _max_queries()
 
     out = []
-    before = None
     for i, address in enumerate(addresses):
         if progress and i % 10 == 0:
             message = "Fetched txids for {} of {} addresses...".format(i, len(addresses))
             progress.report_message(message)
 
+        before = None
         # Get transaction txids for this token account
         for j in range(max_queries):
             logging.info("query %s for address=%s", j, address)


### PR DESCRIPTION
In cases that `max_queries` is less than the total number of queries possible for an address, the `before` value would return the value needed to make the next call for that address rather than None. In that case, not resetting the value of before to None when moving onto the next wallet could cause issues with the `RpcAPI.get_txids` call for the next wallet.